### PR TITLE
save as draft option back

### DIFF
--- a/GYBITG/Stats/NewGameStatViewController.swift
+++ b/GYBITG/Stats/NewGameStatViewController.swift
@@ -197,7 +197,7 @@ class NewGameStatViewController: UIViewController {
             // show the alert
             alert.addAction(YesAction)
             alert.addAction(NoAction)
-            if (self.isDraft) {
+            if (self.isUpdate == false) {
                 alert.addAction(SaveDraftAction)
             }
             self.present(alert, animated: true, completion: nil)


### PR DESCRIPTION
The 'save as draft' option is shown in the stat form view.